### PR TITLE
Working baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Replicating ESM2 at the speed of sound
-This repo is an open-source collaboration to reproduce ESM2-150M validation loss in as little time as possible inspired by the fantastic [modded-nanogpt](https://github.com/KellerJordan/modded-nanogpt) repo. 
+This repo is an open-source collaboration to reproduce ESM2-150M validation loss in as little time as possible inspired by the fantastic [modded-nanogpt](https://github.com/KellerJordan/modded-nanogpt) repo.
+
+## Run
+```
+git clone https://github.com/Synthyra/SpeedRunningESM2 && cd SpeedRunningESM2
+pip install -r requirements.txt
+pip install --pre torch==2.6.0.dev20241203+cu124 --index-url https://download.pytorch.org/whl/nightly/cu124 --upgrade # install torch 2.6.0
+TODO: command to download cached data
+./run.sh
+```
 
 ## Benchmarks to beat
 [OMGprot50](https://huggingface.co/datasets/Synthyra/omg_prot50) test set, 15% MLM objective.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Replicating ESM2 at the speed of sound
 This repo is an open-source collaboration to reproduce ESM2-150M validation loss in as little time as possible inspired by the fantastic [modded-nanogpt](https://github.com/KellerJordan/modded-nanogpt) repo.
 
-## Run
+## Quick Start
+
+Setup environment and train ESM2
+
 ```
 git clone https://github.com/Synthyra/SpeedRunningESM2 && cd SpeedRunningESM2
 pip install -r requirements.txt
 pip install --pre torch==2.6.0.dev20241203+cu124 --index-url https://download.pytorch.org/whl/nightly/cu124 --upgrade # install torch 2.6.0
-TODO: command to download cached data
+python data/cached_omgprot50.py 10 # downloads only the first 1.0B training tokens to save time
 ./run.sh
 ```
 

--- a/data/cached_omgprot50.py
+++ b/data/cached_omgprot50.py
@@ -1,24 +1,16 @@
 import os
 import sys
 from huggingface_hub import hf_hub_download
-
-
+# Download the omgprot50 tokens from huggingface. This
+# saves about an hour of startup time compared to regenerating them.
 def get(fname):
     local_dir = os.path.join(os.path.dirname(__file__), 'omgprot50')
     if not os.path.exists(os.path.join(local_dir, fname)):
-        hf_hub_download(repo_id="Synthyra/omg_prot50", filename=fname, repo_type="dataset", local_dir=local_dir)
-
-
-get("data/valid-00000-of-00001.parquet")
-get("data/test-00000-of-00001.parquet")
-# Full omgprot50, which is roughly 52 billion tokens
-# Each chunk is ~2.3 million sequences, ~600,000,000 tokens, 490 MB
-num_chunks = 91
-
-
+        hf_hub_download(repo_id="lapp0/omg_prot50_packed", filename=fname,
+                        repo_type="dataset", local_dir=local_dir)
+get("omgprot50_val_%06d.bin" % 0)
+num_chunks = 442  # Each chunk is 100M tokens
 if len(sys.argv) >= 2: # we can pass an argument to download less
     num_chunks = int(sys.argv[1])
-
-
 for i in range(1, num_chunks+1):
-    get(f"data/train-{i:05d}-of-00091.parquet")
+    get("omgprot50_train_%06d.bin" % i)

--- a/data/omgprot50.py
+++ b/data/omgprot50.py
@@ -63,7 +63,7 @@ enc = EsmTokenizer.from_pretrained("facebook/esm2_t6_8M_UR50D")
 def tokenize(doc):
     # tokenizes a single document and returns a numpy array of uint8 tokens
     tokens = enc.encode(doc["sequence"], add_special_tokens=True)
-    assert tokens[0] == 0 and (tokens == 0).sum() == 1, "CLS token should always be at start and only at start"
+    assert tokens[0] == 0 and tokens.count(0) == 1, "CLS token should always be at start and only at start"
     tokens_np = np.array(tokens)
     assert (0 <= tokens_np).all() and (tokens_np < 2**8).all(), "token dictionary too large for uint8"
     tokens_np_uint16 = tokens_np.astype(np.uint16) # can use uint8 because only 33 tokens

--- a/data/omgprot50.py
+++ b/data/omgprot50.py
@@ -63,7 +63,8 @@ enc = EsmTokenizer.from_pretrained("facebook/esm2_t6_8M_UR50D")
 def tokenize(doc):
     # tokenizes a single document and returns a numpy array of uint8 tokens
     tokens = enc.encode(doc["sequence"], add_special_tokens=True)
-    tokens_np = np.array([33] + tokens)
+    assert tokens[0] == 0 and (tokens == 0).sum() == 1, "CLS token should always be at start and only at start"
+    tokens_np = np.array(tokens)
     assert (0 <= tokens_np).all() and (tokens_np < 2**8).all(), "token dictionary too large for uint8"
     tokens_np_uint16 = tokens_np.astype(np.uint16) # can use uint8 because only 33 tokens
     return tokens_np_uint16

--- a/run.sh
+++ b/run.sh
@@ -1,1 +1,1 @@
-torchrun --standalone --nproc_per_node=8 train_gpt2.py
+torchrun --standalone --nproc_per_node=8 train_esm2.py

--- a/train_esm2.py
+++ b/train_esm2.py
@@ -326,12 +326,11 @@ class BERT(nn.Module):
         # retain pct_kept%
         keep_mask = self.get_frac_mask(seq, pct_kept, include=~(sub_mask | mlm_mask))
 
-        loss_mask = mlm_mask | sub_mask | keep_mask
-
+        mlm_loss_mask = mlm_mask | sub_mask | keep_mask
         logits = self.encoder_pass(input_seq, sliding_window_size)
         return F.cross_entropy(
             logits.view(-1, logits.size(-1)),
-            seq.masked_fill(~loss_mask, -100).to(dtype=torch.int64).view(-1),
+            seq.masked_fill(~mlm_loss_mask, -100).to(dtype=torch.int64).view(-1),
             ignore_index=-100
         )
 

--- a/train_esm2.py
+++ b/train_esm2.py
@@ -252,8 +252,6 @@ class GPT(nn.Module):
     def __init__(self, config: "GPTConfig"):
         super().__init__()
 
-        self.mlm_p = 0.3  # masking probability: masked language model loss
-
         self.mask_id = 32
         self.bos_id = 33
 

--- a/train_esm2.py
+++ b/train_esm2.py
@@ -440,6 +440,14 @@ class ModelConfig:
 model_config = ModelConfig()
 args = Hyperparameters()
 
+
+def get_param_count(model):
+    total_params = 0
+    for name, param in model.named_parameters():
+        total_params += param.numel()
+    return total_params
+
+
 # set up DDP (distributed data parallel). torchrun sets this env variable
 ddp_rank = int(os.environ['RANK'])
 ddp_local_rank = int(os.environ['LOCAL_RANK'])
@@ -573,7 +581,7 @@ for step in range(args.num_iterations + 1):
         dist.all_reduce(val_loss, op=dist.ReduceOp.AVG)
         val_loss /= val_steps
         # log val loss to console and to logfile
-        print0(f'step:{step}/{args.num_iterations} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/(timed_steps-1):.2f}ms')
+        print0(f'step:{step}/{args.num_iterations} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/(timed_steps-1):.2f}ms perplexity:{(2**val_loss):.4f} param_count:{get_param_count(model),}')
         # start the clock again
         torch.cuda.synchronize()
         t0 = time.perf_counter()

--- a/train_esm2.py
+++ b/train_esm2.py
@@ -550,8 +550,8 @@ def get_lr(it):
         return decay_ratio
 schedulers = [torch.optim.lr_scheduler.LambdaLR(opt, get_lr) for opt in optimizers]
 
-sliding_window_size = torch.tensor(128, dtype=torch.int32, device="cuda")
-sw_prev = 128
+sliding_window_size = torch.tensor(1024 - 128, dtype=torch.int32, device="cuda")
+sw_prev = 1024 - 128
 # Start training loop
 training_time_ms = 0
 # start the clock
@@ -568,9 +568,9 @@ for step in range(args.num_iterations + 1):
         t0 = time.perf_counter()
     timed_steps = float('nan') if step <= 11 else (step - 10) + 1 # <= 11 to avoid bug in val
 
-    # Linearly increase the sliding window size over training in chunks of 128 from 128 -> 2048. By @fernbear.bsky.social
+    # Linearly increase the sliding window size over training in chunks of 128 from 1024 -> 2048. By @fernbear.bsky.social
     frac_done = step / args.num_iterations # training progress
-    sw_size = int(((1 - frac_done) * 128 + frac_done * 2048) // 128) * 128
+    sw_size = int(((1 - frac_done) * 1023 + frac_done * 2048) // 128) * 128
     if sw_size != sw_prev:
         sliding_window_size.copy_(sw_size, non_blocking=True)
         sw_prev = sw_size

--- a/train_esm2.py
+++ b/train_esm2.py
@@ -621,8 +621,8 @@ for step in range(args.num_iterations + 1):
         with contextlib.ExitStack() as stack:
             if i < train_accumulation_steps: # there's no need to sync gradients every accumulation step
                 stack.enter_context(model.no_sync())
-            if step >= 5:
-                stack.enter_context(torch.compiler.set_stance(skip_guard_eval_unsafe=True))
+            #if step >= 5:
+            #    stack.enter_context(torch.compiler.set_stance(skip_guard_eval_unsafe=True))
             model(seq_train, sliding_window_size).backward()
             seq_train = train_loader.next_batch()
     if train_accumulation_steps != 1:

--- a/train_esm2.py
+++ b/train_esm2.py
@@ -5,6 +5,8 @@ with open(sys.argv[0]) as f:
 import uuid
 import time
 import contextlib
+import math
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -312,7 +314,7 @@ class BERT(nn.Module):
     def forward(self, seq, sliding_window_size: torch.Tensor):
         # MLM mask/replace constants from https://www.biorxiv.org/content/10.1101/2022.07.20.500902v3.full.pdf
         pct_masked = 0.12    # 12% of tokens are masked
-        pct_replaced = 0.015 # 1.5% of tokens are randomly replaced 
+        pct_replaced = 0.015 # 1.5% of tokens are randomly replaced
         pct_kept = 0.015     # 1.5% of tokens are kept unchanged
 
         # set pct_masked% to <mask>
@@ -589,7 +591,7 @@ for step in range(args.num_iterations + 1):
         dist.all_reduce(val_loss, op=dist.ReduceOp.AVG)
         val_loss /= val_steps
         # log val loss to console and to logfile
-        print0(f'step:{step}/{args.num_iterations} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/(timed_steps-1):.2f}ms perplexity:{(2**val_loss):.4f} param_count:{get_param_count(model):,}')
+        print0(f'step:{step}/{args.num_iterations} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/(timed_steps-1):.2f}ms perplexity:{(math.e**val_loss):.4f} param_count:{get_param_count(model):,}')
         # start the clock again
         torch.cuda.synchronize()
         t0 = time.perf_counter()

--- a/train_esm2.py
+++ b/train_esm2.py
@@ -581,7 +581,7 @@ for step in range(args.num_iterations + 1):
         dist.all_reduce(val_loss, op=dist.ReduceOp.AVG)
         val_loss /= val_steps
         # log val loss to console and to logfile
-        print0(f'step:{step}/{args.num_iterations} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/(timed_steps-1):.2f}ms perplexity:{(2**val_loss):.4f} param_count:{get_param_count(model),}')
+        print0(f'step:{step}/{args.num_iterations} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/(timed_steps-1):.2f}ms perplexity:{(2**val_loss):.4f} param_count:{get_param_count(model):,}')
         # start the clock again
         torch.cuda.synchronize()
         t0 = time.perf_counter()

--- a/train_esm2.py
+++ b/train_esm2.py
@@ -133,7 +133,7 @@ class Muon(torch.optim.Optimizer):
 
 
 # -----------------------------------------------------------------------------
-# PyTorch nn.Module definitions for the GPT-2 model
+# PyTorch nn.Module definitions
 def norm(x):
     return F.rms_norm(x, (x.size(-1),))
 
@@ -232,7 +232,7 @@ class Block(nn.Module):
 
 
 class ValueEmbedding(nn.Module):
-    def __init__(self, config: "GPTConfig"):
+    def __init__(self, config: "ModelConfig"):
         super().__init__()
         self.embed = nn.ModuleList([
             nn.Embedding(config.vocab_size, config.model_dim)
@@ -246,10 +246,10 @@ class ValueEmbedding(nn.Module):
 
 
 # -----------------------------------------------------------------------------
-# The main GPT-2 model
-class GPT(nn.Module):
+# The main ESM Bert model
+class BERT(nn.Module):
 
-    def __init__(self, config: "GPTConfig"):
+    def __init__(self, config: "ModelConfig"):
         super().__init__()
 
         self.mask_id = 32
@@ -401,7 +401,7 @@ class Hyperparameters:
 
 
 @dataclass
-class GPTConfig:
+class ModelConfig:
     # 33 tokens: https://huggingface.co/Synthyra/ESMplusplus_large/blob/main/modeling_esm_plusplus.py#L868-L874
     # Depth of the number of layers is typically more important than the depth of the hidden dimension for PLMs
     # ESM2-8M has 6 layers, 20 heads, 320 hidden dim: https://huggingface.co/facebook/esm2_t6_8M_UR50D/blob/main/config.json
@@ -414,7 +414,7 @@ class GPTConfig:
     model_dim : int = 768
 
 
-gpt_config = GPTConfig()
+model_config = ModelConfig()
 args = Hyperparameters()
 
 # set up DDP (distributed data parallel). torchrun sets this env variable
@@ -473,7 +473,7 @@ print0(f"Validation DataLoader: total number of tokens: {val_loader.total_num_to
 print0('='*100, logonly=True)
 seq_train = train_loader.next_batch()
 
-model = GPT(gpt_config)
+model = BERT(model_config)
 model = model.cuda().bfloat16()
 for m in model.modules():
     if isinstance(m, CastedLinear):


### PR DESCRIPTION
### Changes
- Manually prefix documents with BOS token ID, and use BOS token to determine document mask
- Change tokens from uint8 -> uint16 to resolve a bug in packing data
- Introduce MLM loss, masking a single token per document
  - Reimplement MLM loss per ESM2 paper (12% masked, 1.5% replaced randomly, 1.5% kept)
- Get `python data/cached_omgprot50.py 10` working

### Baselines

- **Upper Bound: Random Model:** 33 tokens -> perplexity of 33
- **Lower bound:** It is [estimated](https://pmc.ncbi.nlm.nih.gov/articles/PMC1233466/pdf/biophysj00045-0148.pdf) that the shannon entropy of protein sequences is 2.5 bits / amino  (CE loss of 1.73, perplexity of 5.66)
- **This PR:**  achieves [CE loss of 2.48, perplexity of 11.94](https://gist.github.com/lapp0/e076d696df147c7df8028cb2069300d4)
  - trained on 4x4090
  - 85M parameters, 6,000 steps @ batch size = 524,288
- **[ESM2](https://www.biorxiv.org/content/10.1101/2022.07.20.500902v2.full.pdf):** 
![image](https://github.com/user-attachments/assets/157ec370-3f26-44cc-87da-336b29eba64e)
