### PR TITLE
Investigating the test set

### DIFF
--- a/model.py
+++ b/model.py
@@ -191,8 +191,8 @@ class ESM(PreTrainedModel):
         super().__init__(config)
         self.config = config
         tokenizer = EsmTokenizer.from_pretrained('facebook/esm2_t6_8M_UR50D')
-        self.masker = ProteinMasker(tokenizer, 0.20) # 20% masking rate https://arxiv.org/abs/2301.06568
-        self.inference_masker = ProteinMasker(tokenizer, 0.15) # 15% masking rate for inference, ESM2
+        self.masker = ProteinMasker(tokenizer, 0.15) # 20% masking rate https://arxiv.org/abs/2301.06568
+        #self.inference_masker = ProteinMasker(tokenizer, 0.15) # 15% masking rate for inference, ESM2
         self.cls_id = tokenizer.cls_token_id
         self.vocab_size = tokenizer.vocab_size
         self.num_hidden_layers = config.num_hidden_layers
@@ -275,7 +275,7 @@ class ESM(PreTrainedModel):
         return self.get_logits(x)
 
     def inference(self, input_ids: torch.Tensor, sliding_window_size: torch.Tensor = None) -> Tuple[torch.Tensor, Any, Any]:
-        input_ids, labels = self.inference_masker(input_ids)
+        input_ids, labels = self.masker(input_ids)
         logits = self.flex_forward(input_ids, sliding_window_size)
         loss = None
         if labels is not None:

--- a/model.py
+++ b/model.py
@@ -280,7 +280,7 @@ class ESM(PreTrainedModel):
         loss = None
         if labels is not None:
             loss = self.cross_entropy(logits.view(-1, self.vocab_size), labels.view(-1).long())
-        return logits, loss, labels
+        return logits.cpu(), loss.cpu(), labels.cpu()
 
     def forward(self, input_ids: torch.Tensor, sliding_window_size: torch.Tensor) -> torch.Tensor:
         input_ids, labels = self.masker(input_ids)

--- a/train_esm2.py
+++ b/train_esm2.py
@@ -31,6 +31,8 @@ import torch._inductor.config as config
 from torch.nn.parallel import DistributedDataParallel as DDP
 from pathlib import Path
 from sklearn.metrics import precision_score, recall_score, f1_score, accuracy_score, matthews_corrcoef
+import warnings
+warnings.filterwarnings("ignore")
 
 from optimizer import Muon
 from model import ModelConfig, ESM, CastedLinear
@@ -59,7 +61,7 @@ def get_args():
     parser.add_argument('--cooldown_steps', type=int, default=1000, help='number of cooldown steps')
     
     # Evaluation and logging hyperparams
-    parser.add_argument('--valid_loss_every', type=int, default=1000, help='every how many steps to evaluate val loss? 0 for only at the end')
+    parser.add_argument('--eval_every', type=int, default=1000, help='every how many steps to evaluate val loss? 0 for only at the end')
     parser.add_argument('--hf_model_name', type=str, default='Synthyra/esm_speedrun', help='huggingface model name')
     parser.add_argument('--token', type=str, default=None, help='huggingface token')
     parser.add_argument('--save_every', type=int, default=None, help='save every how many steps? None for no saving')
@@ -241,7 +243,7 @@ if __name__ == "__main__":
             sw_prev = sw_size
 
         # once in a while evaluate the validation dataset
-        if args.valid_loss_every > 0 and step % args.valid_loss_every == 0 or last_step:
+        if args.eval_every > 0 and step % args.eval_every == 0 or last_step:
             # stop the clock
             torch.cuda.synchronize()
             training_time_ms += 1000 * (time.perf_counter() - t0)

--- a/train_esm2.py
+++ b/train_esm2.py
@@ -162,8 +162,8 @@ if __name__ == "__main__":
 
     # load tokens
     train_loader = DistributedDataLoader(args.input_bin, batch_size, ddp_rank, ddp_world_size)
-    valid_loader = DistributedDataLoader(args.input_valid_bin, batch_size // 4, ddp_rank, ddp_world_size)
-    test_loader = DistributedDataLoader(args.input_test_bin, batch_size // 4, ddp_rank, ddp_world_size)
+    valid_loader = DistributedDataLoader(args.input_valid_bin, batch_size, ddp_rank, ddp_world_size)
+    test_loader = DistributedDataLoader(args.input_test_bin, batch_size, ddp_rank, ddp_world_size)
     print0(f"Training DataLoader: total number of tokens: {train_loader.total_num_tokens} across {len(train_loader.files)} files")
     print0(f"Validation DataLoader: total number of tokens: {valid_loader.total_num_tokens} across {len(valid_loader.files)} files")
     print0(f"Testing DataLoader: total number of tokens: {test_loader.total_num_tokens} across {len(test_loader.files)} files")

--- a/train_esm2.py
+++ b/train_esm2.py
@@ -160,7 +160,7 @@ if __name__ == "__main__":
 
     # load tokens
     train_loader = DistributedDataLoader(args.input_bin, batch_size, ddp_rank, ddp_world_size)
-    valid_loader = DistributedDataLoader(args.input_valid_bin, batch_size, ddp_rank, ddp_world_size)
+    valid_loader = DistributedDataLoader(args.input_valid_bin, batch_size // 4, ddp_rank, ddp_world_size)
     test_loader = DistributedDataLoader(args.input_test_bin, batch_size // 4, ddp_rank, ddp_world_size)
     print0(f"Training DataLoader: total number of tokens: {train_loader.total_num_tokens} across {len(train_loader.files)} files")
     print0(f"Validation DataLoader: total number of tokens: {valid_loader.total_num_tokens} across {len(valid_loader.files)} files")


### PR DESCRIPTION
 Currently the test set is much more memory intensive than training and also inaccurate compared to the valid set.

Looks like it has something to do with moving the logits and labels around in cuda memory, as when calling `.inference` on valid set or test set we need `batch_size // 4` to not oom.

Have done experiments trying the validation set with `.inference` as well and the loss convergence is much worse than using the regular forward pass. The only difference here is that we mask at 15% instead of 20% and are using a `batch_size // 4`.

So it seems either the input length highly effects performance because of flex attention (which would be a major problem to the usability of the actual model).
or
that training at 20% mask rate and evaluating at 15% leads to much worse performance (this is also not expected vs. normal pLM experiments).

To try and figure this out am considering training an SDPA version and consistent masking rate.