### PR TITLE
padded dataloader

### DIFF
--- a/data/download_omgprot50.py
+++ b/data/download_omgprot50.py
@@ -17,5 +17,5 @@ if __name__ == "__main__":
     args = parser.parse_args()
     get("omgprot50_valid_%06d.bin" % 0)
     get("omgprot50_test_%06d.bin" % 0)
-    for i in range(1, args.num_chunks+1):
+    for i in range(0, args.num_chunks+1):
         get("omgprot50_train_%06d.bin" % i)

--- a/dataloading.py
+++ b/dataloading.py
@@ -61,10 +61,8 @@ class DistributedDataLoader:
 class DistributedPaddedDataLoader(DistributedDataLoader):
     def __init__(self, filename_pattern, seq_len, process_rank, num_processes, eos_id, pad_id):
         super().__init__(filename_pattern, seq_len, process_rank, num_processes)
-        assert (eos_id is None) == (pad_id is None)
         self.eos_id = eos_id
         self.pad_id = pad_id
-        self.padding = (eos_id is not None) and (pad_id is not None)
 
     def reset(self):
         self.current_shard = self.process_rank - self.num_processes
@@ -77,7 +75,7 @@ class DistributedPaddedDataLoader(DistributedDataLoader):
 
     def next_batch(self):
         end_pos = self.current_position + self.batch_size
-        buf = self.tokens[self.current_position : end_pos]
+        buf = self.tokens[self.current_position:end_pos]
         input_ids = buf.to(device="cuda", dtype=torch.int32, non_blocking=True)
         keep = (input_ids == self.eos_id).cumsum(dim=0).argmax().item()
         keep = max(keep or 0, self.batch_size - 2048)

--- a/dataloading.py
+++ b/dataloading.py
@@ -2,21 +2,18 @@ import torch
 from pathlib import Path
 
 
-def _peek_data_shard(file: Path):
+def _load_data_shard(file: Path):
     # only reads the header, returns header data
     # header is 256 int32
     header = torch.from_file(f"{file}", False, 256, dtype=torch.int32)
-    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
-    assert header[1] == 1, "unsupported version"
-    return int(header[2]) # number of tokens (claimed)
-
-
-def _load_data_shard(path: Path, num_tokens):
-    with path.open("rb", buffering=0) as f:
+    assert header[0] == 20240520, 'magic number mismatch in the data .bin file'
+    assert header[1] == 1, 'unsupported version'
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open('rb', buffering=0) as f:
         tokens = torch.empty(num_tokens, dtype=torch.uint8, pin_memory=True)
         f.seek(256 * 4)
         nbytes = f.readinto(tokens.numpy())
-        assert nbytes == num_tokens, "number of tokens read does not match header?"
+        assert nbytes == num_tokens, 'number of tokens read does not match header?'
     return tokens
 
 
@@ -27,6 +24,8 @@ class DistributedDataLoader:
         self.rank = rank
         self.files = sorted(Path.cwd().glob(filename_pattern))
         self.batch_size = batch_size
+        self.local_batch_size = self.batch_size // self.world_size
+
         self.reset()
 
     def reset(self):
@@ -39,43 +38,84 @@ class DistributedDataLoader:
         self.next_shard = (self.next_shard + 1) % len(self.files)
 
     def next_batch(self):
-        local_batch_size = self.batch_size // self.world_size
-        buf = self.tokens[self.pos + self.rank * local_batch_size:][:local_batch_size + 1]
+        buf = self.tokens[self.pos + self.rank * self.local_batch_size:][:self.local_batch_size + 1]
         # by @YouJiacheng: host side async is sufficient;
         # no performance improvement was observed when introducing a separate stream.
-        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True) # inputs
-        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True) # targets
+        sequence = buf.to(device="cuda", dtype=torch.int32, non_blocking=True) # inputs
         # advance current position and load next shard if necessary
         self.pos += self.batch_size
         if self.pos + self.batch_size + 1 >= len(self.tokens):
             self.advance()
-        return inputs, targets
+        return sequence
 
 
 class DistributedPaddedDataLoader(DistributedDataLoader):
-    def __init__(self, filename_pattern, seq_len, process_rank, num_processes, eos_id, pad_id):
-        super().__init__(filename_pattern, seq_len, process_rank, num_processes)
+    def __init__(self, filename_pattern, seq_len, process_rank, num_processes, eos_id, pad_id, max_epochs=1):
         self.eos_id = eos_id
         self.pad_id = pad_id
+        self._leftover_tokens = torch.empty(0, dtype=torch.uint8)
+        self.max_epochs = max_epochs
+        super().__init__(filename_pattern, seq_len, process_rank, num_processes)
 
-    def reset(self):
-        self.current_shard = self.process_rank - self.num_processes
-        self.advance()
+    def advance(self):
+        self.pos = 0
 
-    def advance(self): # advance to next data shard
-        self.current_shard = (self.current_shard + self.num_processes) % len(self.files)
-        self.current_position = 0
-        self.tokens = _load_data_shard(self.files[self.current_shard], self.files_num_tokens[self.current_shard])
+        if self.next_shard // len(self.files) >= self.max_epochs:
+            raw_tokens = self._leftover_tokens
+        else:
+            self.next_shard += 1
+            raw_tokens = _load_data_shard(self.files[self.next_shard % len(self.files)])
+            raw_tokens = torch.cat([self._leftover_tokens, raw_tokens], dim=0)
+
+        if not raw_tokens.numel():
+            self._leftover_tokens = torch.empty(0, dtype=torch.uint8)
+            self.tokens = None
+            return
+
+        processed_chunks = []
+        curr_batch_len = 0
+
+        eos_positions = (raw_tokens == self.eos_id).nonzero(as_tuple=True)[0]
+        for i in range(len(eos_positions)-1):
+            sample_end = eos_positions[i+1]
+            sample = raw_tokens[eos_positions[i]+1:sample_end+1]  # One sample: "CLS ... EOS"
+
+            assert sample[0] == 0 and sample[-1] == 2, (sample[0], sample[-1])
+            assert curr_batch_len < self.local_batch_size, curr_batch_len
+
+            # if adding sample exceeds the batch size resulting in truncation, pad to end of batch, starting a fresh batch
+            if len(sample) + curr_batch_len >= self.local_batch_size:
+                num_pad = self.local_batch_size - curr_batch_len
+                processed_chunks.append(torch.full((num_pad,), self.pad_id))
+                curr_batch_len = 0
+
+            # if len(sample) > local batch size, chunk evenly, making multiple padded batches, starting a fresh batch
+            if len(sample) > self.local_batch_size:
+                for split_sample in torch.chunk(sample, len(sample) // self.local_batch_size + 1):
+                    processed_chunks.append(split_sample)
+                    num_pad = self.local_batch_size - len(split_sample)
+                    processed_chunks.append(torch.full((num_pad,), self.pad_id))
+                curr_batch_len = 0
+                continue
+
+            processed_chunks.append(sample)
+            curr_batch_len += len(sample)
+
+        self._leftover_tokens = raw_tokens[sample_end+1:]
+        self.tokens = torch.cat(processed_chunks, dim=0)
 
     def next_batch(self):
-        end_pos = self.current_position + self.batch_size
-        buf = self.tokens[self.current_position:end_pos]
-        input_ids = buf.to(device="cuda", dtype=torch.int32, non_blocking=True)
-        keep = (input_ids == self.eos_id).cumsum(dim=0).argmax().item()
-        keep = max(keep or 0, self.batch_size - 2048)
-        input_ids[keep + 1:] = self.pad_id
-        # advance current position and load next shard if necessary
-        self.current_position += keep
-        if self.current_position + self.batch_size >= len(self.tokens):
-            self.advance()
-        return input_ids
+        if self.tokens is None:
+            return None
+
+        seq = super().next_batch()
+
+        # TODO: for verification of proper padding, can remove
+        if False:
+            # first token has to be BOS or there is no BOS
+            assert seq[0] == 0 or (seq == 0).sum() == 0, "first bos or no bos"
+            # last token has to be EOS or there is no EOS
+            first_pad_idx = (seq == self.pad_id).nonzero(as_tuple=True)[0][0].item()
+            assert (seq == self.eos_id).sum() == 0 or seq[first_pad_idx-1] == self.eos_id
+
+        return seq

--- a/dataloading.py
+++ b/dataloading.py
@@ -109,13 +109,4 @@ class DistributedPaddedDataLoader(DistributedDataLoader):
             return None
 
         seq = super().next_batch()
-
-        # TODO: for verification of proper padding, can remove
-        if False:
-            # first token has to be BOS or there is no BOS
-            assert seq[0] == 0 or (seq == 0).sum() == 0, "first bos or no bos"
-            # last token has to be EOS or there is no EOS
-            first_pad_idx = (seq == self.pad_id).nonzero(as_tuple=True)[0][0].item()
-            assert (seq == self.eos_id).sum() == 0 or seq[first_pad_idx-1] == self.eos_id
-
         return seq

--- a/dataloading.py
+++ b/dataloading.py
@@ -56,3 +56,34 @@ class DistributedDataLoader:
         if self.current_position + batch_size >= len(self.tokens):
             self.advance()
         return input_ids
+
+
+class DistributedPaddedDataLoader(DistributedDataLoader):
+    def __init__(self, filename_pattern, seq_len, process_rank, num_processes, eos_id, pad_id):
+        super().__init__(filename_pattern, seq_len, process_rank, num_processes)
+        assert (eos_id is None) == (pad_id is None)
+        self.eos_id = eos_id
+        self.pad_id = pad_id
+        self.padding = (eos_id is not None) and (pad_id is not None)
+
+    def reset(self):
+        self.current_shard = self.process_rank - self.num_processes
+        self.advance()
+
+    def advance(self): # advance to next data shard
+        self.current_shard = (self.current_shard + self.num_processes) % len(self.files)
+        self.current_position = 0
+        self.tokens = _load_data_shard(self.files[self.current_shard], self.files_num_tokens[self.current_shard])
+
+    def next_batch(self):
+        end_pos = self.current_position + self.batch_size
+        buf = self.tokens[self.current_position : end_pos]
+        input_ids = buf.to(device="cuda", dtype=torch.int32, non_blocking=True)
+        keep = (input_ids == self.eos_id).cumsum(dim=0).argmax().item()
+        keep = max(keep or 0, self.batch_size - 2048)
+        input_ids[keep + 1:] = self.pad_id
+        # advance current position and load next shard if necessary
+        self.current_position += keep
+        if self.current_position + self.batch_size >= len(self.tokens):
+            self.advance()
+        return input_ids

--- a/model.py
+++ b/model.py
@@ -171,10 +171,10 @@ class Block(nn.Module):
 
 
 class ValueEmbedding(nn.Module):
-    def __init__(self, config: "ModelConfig"):
+    def __init__(self, config: "ModelConfig", padding_idx):
         super().__init__()
         self.embed = nn.ModuleList([
-            nn.Embedding(config.vocab_size, config.hidden_size)
+            nn.Embedding(config.vocab_size, config.hidden_size, padding_idx=padding_idx)
             for _ in range(config.num_hidden_layers // 2)
         ])
 
@@ -207,11 +207,11 @@ class ESM(PreTrainedModel):
         # Add learnable skip connection weights for decoder layers
         self.skip_weights = nn.Parameter(torch.ones(self.num_decoder_layers))
 
-        self.embed = nn.Embedding(self.vocab_size, config.hidden_size)
+        self.embed = nn.Embedding(self.vocab_size, config.hidden_size, padding_idx=tokenizer.pad_token_id)
         self.blocks = nn.ModuleList([Block(config) for _ in range(config.num_hidden_layers)])
         # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual learning
         # U-net structure on token value embeddings by @leloykun
-        self.value_embeds = ValueEmbedding(config)
+        self.value_embeds = ValueEmbedding(config, padding_idx=tokenizer.pad_token_id)
         self.lm_head = CastedLinear(config.hidden_size, self.vocab_size)
         self.lm_head.weight.data.zero_() # @Grad62304977
         self.cross_entropy = nn.CrossEntropyLoss()


### PR DESCRIPTION
As discussed in https://github.com/Synthyra/SpeedRunningESM2/pull/3

This removes the issue of a smaller batch size resulting in a larger number of truncations. Should be used for validation / test. Unclear whether it should be used for training - it's more sample efficient, but 4% slower and has fewer tokens per batch.