### PR TITLE
Finish fixes for padded dataloader

### DIFF
--- a/dataloading.py
+++ b/dataloading.py
@@ -38,13 +38,13 @@ class DistributedDataLoader:
         self.next_shard = (self.next_shard + 1) % len(self.files)
 
     def next_batch(self):
-        buf = self.tokens[self.pos + self.rank * self.local_batch_size:][:self.local_batch_size + 1]
+        buf = self.tokens[self.pos + self.rank * self.local_batch_size:][:self.local_batch_size]
         # by @YouJiacheng: host side async is sufficient;
         # no performance improvement was observed when introducing a separate stream.
         sequence = buf.to(device="cuda", dtype=torch.int32, non_blocking=True) # inputs
         # advance current position and load next shard if necessary
         self.pos += self.batch_size
-        if self.pos + self.batch_size + 1 >= len(self.tokens):
+        if self.pos + self.batch_size >= len(self.tokens):
             self.advance()
         return sequence
 
@@ -60,25 +60,27 @@ class DistributedPaddedDataLoader(DistributedDataLoader):
     def advance(self):
         self.pos = 0
 
-        if self.next_shard // len(self.files) >= self.max_epochs:
-            raw_tokens = self._leftover_tokens
-        else:
-            self.next_shard += 1
+        # handle epoch limit
+        if self.next_shard // len(self.files) < self.max_epochs:
             raw_tokens = _load_data_shard(self.files[self.next_shard % len(self.files)])
             raw_tokens = torch.cat([self._leftover_tokens, raw_tokens], dim=0)
-
+            self.next_shard += 1
+        else:
+            raw_tokens = self._leftover_tokens
         if not raw_tokens.numel():
             self._leftover_tokens = torch.empty(0, dtype=torch.uint8)
-            self.tokens = None
+            self.tokens = torch.empty(0, dtype=torch.uint8)
             return
 
         processed_chunks = []
         curr_batch_len = 0
 
         eos_positions = (raw_tokens == self.eos_id).nonzero(as_tuple=True)[0]
-        for i in range(len(eos_positions)-1):
-            sample_end = eos_positions[i+1]
-            sample = raw_tokens[eos_positions[i]+1:sample_end+1]  # One sample: "CLS ... EOS"
+
+        for i in range(len(eos_positions)):
+            curr_eos = eos_positions[i]
+            prev_eos_plus_one = 0 if i == 0 else eos_positions[i-1] + 1  # EOS_idx + 1 = CLS_idx
+            sample = raw_tokens[prev_eos_plus_one:curr_eos+1]  # One sample: "CLS ... EOS"
 
             assert sample[0] == 0 and sample[-1] == 2, (sample[0], sample[-1])
             assert curr_batch_len < self.local_batch_size, curr_batch_len
@@ -101,21 +103,5 @@ class DistributedPaddedDataLoader(DistributedDataLoader):
             processed_chunks.append(sample)
             curr_batch_len += len(sample)
 
-        self._leftover_tokens = raw_tokens[sample_end+1:]
+        self._leftover_tokens = raw_tokens[curr_eos+1:]
         self.tokens = torch.cat(processed_chunks, dim=0)
-
-    def next_batch(self):
-        if self.tokens is None:
-            return None
-
-        seq = super().next_batch()
-
-        # TODO: for verification of proper padding, can remove
-        if False:
-            # first token has to be BOS or there is no BOS
-            assert seq[0] == 0 or (seq == 0).sum() == 0, "first bos or no bos"
-            # last token has to be EOS or there is no EOS
-            first_pad_idx = (seq == self.pad_id).nonzero(as_tuple=True)[0][0].item()
-            assert (seq == self.eos_id).sum() == 0 or seq[first_pad_idx-1] == self.eos_id
-
-        return seq

--- a/train_esm2.py
+++ b/train_esm2.py
@@ -248,15 +248,14 @@ if __name__ == "__main__":
             # run validation batches
             model.eval()
             valid_loader.reset()
-            val_loss = 0.0
-            valid_tokens = 0
+            val_loss, valid_tokens = 0.0, 0
             with torch.no_grad():
-                val_input_ids = valid_loader.next_batch()
-                while val_input_ids.numel():
-                    batch_valid_tokens = (val_input_ids != 1).sum()
+                input_ids = valid_loader.next_batch()
+                while input_ids.numel():
+                    batch_valid_tokens = (input_ids != pad_id).sum()
                     valid_tokens += batch_valid_tokens
-                    val_loss += model(val_input_ids, sliding_window_size) * batch_valid_tokens
-                    val_input_ids = valid_loader.next_batch()
+                    val_loss += model(input_ids, sliding_window_size) * batch_valid_tokens
+                    input_ids = valid_loader.next_batch()
             if ddp_world_size > 1:
                 dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
                 dist.all_reduce(valid_tokens, op=dist.ReduceOp.SUM)


### PR DESCRIPTION
See https://github.com/Synthyra/SpeedRunningESM2/pull/5#issuecomment-2568444843
- don't skip first sample
- average val / test loss by token count (don't change how gradients are averaged though)
- don't add 1 to seq len (artifact from causal lm loss)